### PR TITLE
fix: IndexError: list index out of range during install

### DIFF
--- a/ls_shop/www/products/list.py
+++ b/ls_shop/www/products/list.py
@@ -24,7 +24,7 @@ def get_filter_brands(filters=None):
 	query = query.select(item.brand).distinct().orderby(item.brand)
 	brands = query.run(pluck=True)
 	print(brands)
-	if not brands[0]:
+	if not brands or not brands[0]:
 		return []
 	brands = [b.title() for b in brands]
 	return brands


### PR DESCRIPTION
### Summary
This PR fixes an `IndexError: list index out of range` that occurs during installation.

### Changes
- Added a check to prevent accessing a list element that doesn't exist
- Ensured the installation script runs without raising IndexError

### Notes
- Tested the installation locally after fix
- No breaking changes introduced
