### PR TITLE
fix(storefront): render theme css via jinja method instead of doc method

### DIFF
--- a/ls_shop/hooks.py
+++ b/ls_shop/hooks.py
@@ -116,7 +116,7 @@ doc_events = {
 
 jinja = {
 	"filters": ["ls_shop.utils.can_return"],
-	"methods": ["ls_shop.utils.get_currency_symbol"],
+	"methods": ["ls_shop.utils.format_theme_css", "ls_shop.utils.get_currency_symbol"],
 }
 
 

--- a/ls_shop/templates/layout.html
+++ b/ls_shop/templates/layout.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="/assets/ls_shop/css/tailwind.css">
     
     <!-- Dynamic Theme CSS -->
-    {{ settings.generate_theme_css()|safe }}
+    {{ format_theme_css()|safe }}
 
     
     <!-- https://alpinejs.dev/start-here -->

--- a/ls_shop/utils.py
+++ b/ls_shop/utils.py
@@ -219,6 +219,11 @@ def get_cod_configuration():
 	)
 
 
+def format_theme_css():
+	# jinja's safe globals return documents as plain dicts, so controller methods are unreachable from templates
+	return frappe.get_cached_doc("Lifestyle Settings", "Lifestyle Settings").generate_theme_css()
+
+
 def get_currency_symbol():
 	currency = frappe.get_cached_value("Global Defaults", "Global Defaults", "default_currency")
 	if currency == "SAR" or frappe.conf.developer_mode:


### PR DESCRIPTION
### Symptom

Every storefront page returned HTTP 500. `GET /` (→ `/en`):

```
File "apps/ls_shop/ls_shop/templates/layout.html", line 21, in top-level template code
  {{ settings.generate_theme_css()|safe }}
TypeError: 'NoneType' object is not callable
```

### Root cause

Not a broken controller — `LifestyleSettings.generate_theme_css` exists and resolves fine in a bench console. The problem is the Jinja sandbox: `frappe.get_cached_doc` exposed to templates is **not** `frappe.get_cached_doc`. In `frappe/utils/safe_exec.py` the restricted globals map it to:

```python
def safer_get_cached_doc(*args, **kwargs):
	return SafeDoc(frappe.get_cached_doc(*args, **kwargs).as_dict())
```

So `settings` in the template is a `SafeDoc` over `as_dict()` — fields still resolve, controller methods do not, and `SafeDoc.__getattr__` yields `None` rather than raising. Calling it blows up. Field access (`settings.store_name`, `settings.footer_sections`, …) is unaffected, which is why only this one line failed.

### Fix

Expose the theme CSS through the app's existing `jinja` hook instead of calling a controller method off a template-side document:

- `ls_shop/utils.py` — new `format_theme_css()` that reads the cached settings document server-side and returns the existing `generate_theme_css()` output.
- `ls_shop/hooks.py` — registered under the existing `jinja["methods"]` list.
- `ls_shop/templates/layout.html` — `{{ format_theme_css()|safe }}`.

No new abstraction, no duplicated CSS generation, and `layout.html` is shared by every storefront page so all of them are covered by the one change. Audited the rest of `templates/` and `www/` — this was the only method call on a template-side document; everything else is plain field access.

### Verification

Reproduced first, then fixed (same running server, cache cleared between):

```
pre-fix  / -> 500
post-fix / -> 200
```

All storefront routes, after seeding demo products:

```
/                                  -> 200
/en                                -> 200
/en/products                       -> 200
/en/products/brake-pads-black      -> 200
/ar/products/brake-pads-black      -> 200
/en/cart                           -> 200
```

`/en/cart/checkout` and `/en/account/dashboard` return 403 as Guest — that is their intended auth guard, not this bug.

Theme variables are actually emitted (not silently swallowed) — 8 `--ls-primary` occurrences in the rendered product detail page.

Lint: `ruff check ls_shop/` passes; `ruff format --check` clean on all three changed files.

### Out of scope (noticed while verifying, not fixed here)

`ls_shop/install_demo_data.py` still calls `create_website_items()` / `fix_product_routes()` against the `Website Item` doctype, which no longer exists after the webshop-dependency removal — demo installation aborts and rolls back. `create_item_attributes()` also creates `Size` with `numeric_values=1` and no range, which fails validation. Both are separate pre-existing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
